### PR TITLE
Wildcard fixes and exclusion support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ erl_crash.dump
 *.ez
 
 /.elixir_ls
+
+# IntelliJ files
+/.idea
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: elixir
 elixir:
-  - 1.3.2
+  - 1.5.3
 otp_release:
   - 18.3
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: elixir
 elixir:
   - 1.3.2

--- a/lib/domainatrex.ex
+++ b/lib/domainatrex.ex
@@ -53,28 +53,83 @@ defmodule Domainatrex do
     |> Enum.sort_by(&length/1)
     |> Enum.reverse
 
+  exclusions =
+    suffixes
+    |> Enum.filter(&(&1 |> Enum.at(-1) |> String.starts_with?("!")))
+    |> Enum.reduce(%{}, fn (k, acc) ->
+      [head | tail] = Enum.reverse(k)
+      key = tail |> Enum.reverse() |> Enum.join(".")
+      val = head |> String.slice(1..-1)
+      if Map.has_key?(acc, key) do
+        new = [val | Map.get(acc, key)]
+        %{acc | key: new}
+      else
+        Map.put(acc, key, [val])
+      end
+    end)
+
+  suffixes =
+    suffixes
+    |> Enum.reject(&(&1 |> Enum.at(-1) |> String.starts_with?("!")))
+
   Enum.each(suffixes, fn(suffix) ->
     if List.last(suffix) == "*" do
       case length(suffix) do
         2 ->
-          defp match([unquote(Enum.at(suffix,0)), a]) do
-            format_response([unquote(Enum.at(suffix,0))], [a])
-          end
-          defp match([unquote(Enum.at(suffix,0)), a, b]) do
-            format_response([unquote(Enum.at(suffix,0))], [a,b])
-          end
-          defp match([unquote(Enum.at(suffix,0)) | _] = args) do
-            format_response(Enum.slice(args, 0,2), Enum.slice(args, 2, 10))
+          exclude = Map.get(exclusions, Enum.at(suffix,0), [])
+          if exclude != [] do
+            defp match([unquote(Enum.at(suffix,0)), head | tail]) when head in unquote(exclude) do
+              format_response([unquote(Enum.at(suffix,0))], [head | tail])
+            end
+            defp match([unquote(Enum.at(suffix,0)), head | tail]) when head not in unquote(exclude) do
+              format_response([unquote(Enum.at(suffix,0)), head], tail)
+            end
+          else
+            defp match([unquote(Enum.at(suffix,0)), head | tail]) do
+              format_response([unquote(Enum.at(suffix,0)), head], tail)
+            end
           end
         3 ->
-          defp match([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), a]) do
-            format_response([unquote(Enum.at(suffix,0)),unquote(Enum.at(suffix,1))], [a])
+          exclude = Map.get(exclusions, "#{Enum.at(suffix,0)}.#{Enum.at(suffix,1)}", [])
+          if exclude != [] do
+            defp match([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), head | tail]) when head in unquote(exclude) do
+              format_response([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1))], [head | tail])
+            end
+            defp match([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), head | tail]) when head not in unquote(exclude) do
+              format_response([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), head], tail)
+            end
+          else
+            defp match([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), head | tail]) do
+              format_response([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), head], tail)
+            end
           end
-          defp match([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), a, b]) do
-            format_response([unquote(Enum.at(suffix,0)),unquote(Enum.at(suffix,1))], [a, b])
+        4 ->
+          exclude = Map.get(exclusions, "#{Enum.at(suffix,0)}.#{Enum.at(suffix,1)}.#{Enum.at(suffix,2)}", [])
+          if exclude != [] do
+            defp match([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), unquote(Enum.at(suffix,2)), head | tail]) when head in unquote(exclude) do
+              format_response([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), unquote(Enum.at(suffix,2))], [head | tail])
+            end
+            defp match([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), unquote(Enum.at(suffix,2)), head | tail]) when head not in unquote(exclude) do
+              format_response([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), unquote(Enum.at(suffix,2)), head], tail)
+            end
+          else
+            defp match([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), unquote(Enum.at(suffix,2)), head | tail]) do
+              format_response([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), unquote(Enum.at(suffix,2)), head], tail)
+            end
           end
-          defp match([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)) | _] = args) do
-            format_response(Enum.slice(args, 0,3), Enum.slice(args, 3, 10))
+        5 ->
+          exclude = Map.get(exclusions, "#{Enum.at(suffix,0)}.#{Enum.at(suffix,1)}.#{Enum.at(suffix,2)}.#{Enum.at(suffix,3)}", [])
+          if exclude != [] do
+            defp match([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), unquote(Enum.at(suffix,2)), unquote(Enum.at(suffix,3)), head | tail]) when head in unquote(exclude) do
+              format_response([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), unquote(Enum.at(suffix,2)), unquote(Enum.at(suffix,3))], [head | tail])
+            end
+            defp match([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), unquote(Enum.at(suffix,2)), unquote(Enum.at(suffix,3)), head | tail]) when head not in unquote(exclude) do
+              format_response([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), unquote(Enum.at(suffix,2)), unquote(Enum.at(suffix,3)), head], tail)
+            end
+          else
+            defp match([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), unquote(Enum.at(suffix,2)), head | tail]) do
+              format_response([unquote(Enum.at(suffix,0)), unquote(Enum.at(suffix,1)), unquote(Enum.at(suffix,2)), unquote(Enum.at(suffix,3)), head], tail)
+            end
           end
       end
     else

--- a/lib/domainatrex.ex
+++ b/lib/domainatrex.ex
@@ -3,7 +3,7 @@ defmodule Domainatrex do
   @moduledoc """
   Documentation for Domainatrex.
   """
-  @public_suffix_list_url 'https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat'
+  @public_suffix_list_url Application.get_env(:domainatrex, :public_suffix_list_url, 'https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat')
   @public_suffix_list nil
 
   :inets.start

--- a/lib/domainatrex.ex
+++ b/lib/domainatrex.ex
@@ -23,8 +23,14 @@ defmodule Domainatrex do
       end
   end
 
-  string = @public_suffix_list |> String.split("// ===END ICANN DOMAINS===") |> List.first
   custom_suffixes = Application.get_env(:domainatrex, :custom_suffixes, [])
+  string = if Application.get_env(:domainatrex, :include_private, false) do
+    @public_suffix_list
+  else
+    @public_suffix_list
+    |> String.split("// ===END ICANN DOMAINS===")
+    |> List.first
+  end
   suffixes =
     string
     |> String.split("\n")

--- a/lib/domainatrex.ex
+++ b/lib/domainatrex.ex
@@ -4,21 +4,21 @@ defmodule Domainatrex do
   Documentation for Domainatrex.
   """
   @public_suffix_list_url Application.get_env(:domainatrex, :public_suffix_list_url, 'https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat')
+  @fallback_local_copy Application.get_env(:domainatrex, :fallback_local_copy, "lib/public_suffix_list.dat")
   @public_suffix_list nil
 
   :inets.start
   :ssl.start
-
   case :httpc.request(:get, {@public_suffix_list_url, []}, [], []) do
     {:ok, {_, _, string}} ->
       @public_suffix_list to_string(string)
     _ ->
-      case File.read "lib/public_suffix_list.dat" do
+      case File.read @fallback_local_copy do
         {:ok, string} ->
-          Logger.error "[Domainatrex] Could not read the public suffix list from the internet, trying to read from the backup at lib/public_suffix_list.dat"
+          Logger.error "[Domainatrex] Could not read the public suffix list from the internet, trying to read from the backup at #{@fallback_local_copy}"
           @public_suffix_list string
         _ ->
-          Logger.error "[Domainatrex] Could not read the public suffix list, please make sure that you either have an internet connection or lib/public_suffix_list.dat exists"
+          Logger.error "[Domainatrex] Could not read the public suffix list, please make sure that you either have an internet connection or #{@fallback_local_copy} exists"
           @public_suffix_list nil
       end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Domainatrex.Mixfile do
   def project do
     [app: :domainatrex,
      version: "2.2.0",
-     elixir: "~> 1.3",
+     elixir: "~> 1.5",
      test_coverage: [tool: ExCoveralls],
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/domainatrex_test.exs
+++ b/test/domainatrex_test.exs
@@ -26,10 +26,27 @@ defmodule DomainatrexTest do
   ## *.bd
   test "domains with wildcard" do
     assert Domainatrex.parse("www.techtunes.com.bd") == {:ok, %{domain: "techtunes", subdomain: "www", tld: "com.bd"}}
-    assert Domainatrex.parse("www.techtunes.bd") == {:ok, %{domain: "techtunes", subdomain: "www", tld: "bd"}}
-    assert Domainatrex.parse("send.kawasaki.jp") == {:ok, %{domain: "send", subdomain: "", tld: "kawasaki.jp"}}
-    assert Domainatrex.parse("www.send.kawasaki.jp") == {:ok, %{domain: "send", subdomain: "www", tld: "kawasaki.jp"}}
+    assert Domainatrex.parse("www.techtunes.bd") == {:ok, %{domain: "www", subdomain: "", tld: "techtunes.bd"}}
+    assert Domainatrex.parse(".send.kawasaki.jp") == {:ok, %{domain: "", subdomain: "", tld: "send.kawasaki.jp"}}
+    assert Domainatrex.parse("www.send.kawasaki.jp") == {:ok, %{domain: "www", subdomain: "", tld: "send.kawasaki.jp"}}
     assert Domainatrex.parse("www.elb.send.kawasaki.jp") == {:ok, %{domain: "elb", subdomain: "www", tld: "send.kawasaki.jp"}}
+
+    assert Domainatrex.parse("www.anything.ck") == {:ok, %{domain: "www", subdomain: "", tld: "anything.ck"}}
+    assert Domainatrex.parse("www2.www.anything2.ck") == {:ok, %{domain: "www", subdomain: "www2", tld: "anything2.ck"}}
+
+    assert Domainatrex.parse(".www.sch.uk") == {:ok, %{domain: "", subdomain: "", tld: "www.sch.uk"}}
+    assert Domainatrex.parse("www2.www.sch.uk") == {:ok, %{domain: "www2", subdomain: "", tld: "www.sch.uk"}}
+    assert Domainatrex.parse("some.host.www2.www.sch.uk") == {:ok, %{domain: "www2", subdomain: "some.host", tld: "www.sch.uk"}}
+  end
+
+  test "domains with wildcard and exclusions" do
+    assert Domainatrex.parse("www.send.kawasaki.jp") == {:ok, %{domain: "www", subdomain: "", tld: "send.kawasaki.jp"}}
+    assert Domainatrex.parse("www.elb.send.kawasaki.jp") == {:ok, %{domain: "elb", subdomain: "www", tld: "send.kawasaki.jp"}}
+    assert Domainatrex.parse("city.kawasaki.jp") == {:ok, %{domain: "city", subdomain: "", tld: "kawasaki.jp"}}
+    assert Domainatrex.parse("www.city.kawasaki.jp") == {:ok, %{domain: "city", subdomain: "www", tld: "kawasaki.jp"}}
+
+    assert Domainatrex.parse("www.ck") == {:ok, %{domain: "www", subdomain: "", tld: "ck"}}
+    assert Domainatrex.parse("www2.www.ck") == {:ok, %{domain: "www", subdomain: "www2", tld: "ck"}}
   end
 
   test "nonsense" do


### PR DESCRIPTION
Hey, hi Ale, I needed some features that you did to the library so I tried them and it worked fine at the beginning, but I found some issues / not desired behaviour with wildcard domains, so I fixed them and probably you could be interested.

Basically any `<wildcard>.domain` should be considered a TLD, so `send.kawasaki.jp` is a whole TLD, not `kawasaki.jp`.

Additionally I added support for exclusions (although they are just like 8 in total)

Sorry for mixing up my "configuration" options, but I tried your features on top of mine.

Regards.